### PR TITLE
Add `project:astral-sh/ty` and `category:type-checkers`

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -10,6 +10,8 @@ categories:
     title: "Package Managers"
   - category: "linters"
     title: "Linters & Style Checkers"
+  - category: "type-checkers"
+    title: "Type Checkers"
 
 labels:
   - label: "written-in-rust"
@@ -25,3 +27,7 @@ projects:
     github_id: astral-sh/ruff
     labels: ["written-in-rust"]
     category: "linters"
+  - name: ty
+    github_id: astral-sh/ty
+    labels: ["written-in-rust"]
+    category: "type-checkers"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [x] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes. We recommend only to add, update, or remove one project per pull request. If your PR adds a new project, just put the project name and a short description of the project here.-->
[An extremely fast Python type checker and language server, written in Rust.](https://github.com/astral-sh/ty)

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.

## Summary by Sourcery

Add a new "type-checkers" category and include the Rust-based Python type checker "ty" under it

New Features:
- Add "ty" project (astral-sh/ty) as a Rust-based Python type checker

Enhancements:
- Introduce a "type-checkers" category for organizing type checker projects